### PR TITLE
feature/pickle 74 전략 생성 api 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -80,7 +80,7 @@ subprojects {
 
     project(':pickle-common') {
         dependencies {
-//            implementation project(':real-common')
+            implementation project(':real-common')
         }
     }
 

--- a/pickle-common/build.gradle
+++ b/pickle-common/build.gradle
@@ -28,10 +28,10 @@ ext {
 }
 
 dependencies {
-
-//	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-//	implementation 'com.mysql:mysql-connector-j:9.0.0'
-//	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'com.mysql:mysql-connector-j:9.0.0'
+	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 }
 
 dependencyManagement {

--- a/pickle-common/src/main/java/com/example/pickle_common/PickleCommonApplication.java
+++ b/pickle-common/src/main/java/com/example/pickle_common/PickleCommonApplication.java
@@ -2,7 +2,8 @@ package com.example.pickle_common;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-@SpringBootApplication
+
+@SpringBootApplication(scanBasePackages = {"com.example.pickle_common", "com.example.real_common"})
 public class PickleCommonApplication {
 
 	public static void main(String[] args) {

--- a/pickle-common/src/main/java/com/example/pickle_common/strategy/controller/StrategyController.java
+++ b/pickle-common/src/main/java/com/example/pickle_common/strategy/controller/StrategyController.java
@@ -1,0 +1,32 @@
+package com.example.pickle_common.strategy.controller;
+
+import com.example.pickle_common.strategy.dto.CreateStrategyRequestDto;
+import com.example.pickle_common.strategy.dto.CreateStrategyResponseDto;
+import com.example.pickle_common.strategy.service.StrategyService;
+import com.example.real_common.global.common.CommonResDto;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/strategy")
+@Validated
+//@Slf4j
+public class StrategyController {
+    private final StrategyService strategyService;
+
+    @PostMapping
+    public ResponseEntity<CommonResDto<?>> postStrategy(@RequestBody @Valid CreateStrategyRequestDto createStrategyRequestDto) {
+        CreateStrategyResponseDto responseDto = strategyService.postStrategy(createStrategyRequestDto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(new CommonResDto<>(1, "전략 생성 성공", responseDto));
+    }
+}

--- a/pickle-common/src/main/java/com/example/pickle_common/strategy/controller/StrategyController.java
+++ b/pickle-common/src/main/java/com/example/pickle_common/strategy/controller/StrategyController.java
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Slf4j
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/strategy")
+@RequestMapping("/pickle-common/api/strategy")
 @Validated
 //@Slf4j
 public class StrategyController {

--- a/pickle-common/src/main/java/com/example/pickle_common/strategy/dto/CreateStrategyRequestDto.java
+++ b/pickle-common/src/main/java/com/example/pickle_common/strategy/dto/CreateStrategyRequestDto.java
@@ -1,0 +1,57 @@
+package com.example.pickle_common.strategy.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
+import lombok.Getter;
+
+import java.util.List;
+
+/**
+ * "pdId": PB식별ID,
+ *     "customerId": 고객식별ID,
+ *     "consultingHistoryId": 상담기록ID
+ *     "name": "생성할 전략 이름",
+ */
+@Getter
+public class CreateStrategyRequestDto {
+    @Positive
+    private int pbId;
+
+    @Positive
+    private int customerId;
+
+    @Positive
+    private int consultingHistoryId;
+
+    private String name;
+
+    private List<@Valid CategoryDto> categoryList;
+
+    @Getter
+    public static class CategoryDto {
+        @NotBlank
+        private String category;
+
+        @Positive
+        private int categoryRatio;
+
+        private List<@Valid ProductDto> productList;
+    }
+
+    @Getter
+    public static class ProductDto {
+        @NotBlank
+        private String code;
+
+        @NotBlank
+        private String name;
+
+        @Positive
+        private int ratio;
+
+        @NotBlank
+        private String themeName;
+    }
+
+}

--- a/pickle-common/src/main/java/com/example/pickle_common/strategy/dto/CreateStrategyResponseDto.java
+++ b/pickle-common/src/main/java/com/example/pickle_common/strategy/dto/CreateStrategyResponseDto.java
@@ -1,0 +1,12 @@
+package com.example.pickle_common.strategy.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class CreateStrategyResponseDto {
+    int strategyId;
+}

--- a/pickle-common/src/main/java/com/example/pickle_common/strategy/entity/CategoryComposition.java
+++ b/pickle-common/src/main/java/com/example/pickle_common/strategy/entity/CategoryComposition.java
@@ -1,0 +1,24 @@
+package com.example.pickle_common.strategy.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Builder
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class CategoryComposition {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int categoryCompositionId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "strategy_id")
+    private Strategy strategy;
+
+    private String categoryName;
+
+    private double categoryRatio;
+
+}

--- a/pickle-common/src/main/java/com/example/pickle_common/strategy/entity/Product.java
+++ b/pickle-common/src/main/java/com/example/pickle_common/strategy/entity/Product.java
@@ -1,0 +1,30 @@
+package com.example.pickle_common.strategy.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Product {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int productId;
+
+    private int themeId;
+
+    private String code;
+    private String name;
+    private String imgUrl;
+    private String themeName;
+    private String categoryName;
+}

--- a/pickle-common/src/main/java/com/example/pickle_common/strategy/entity/ProductComposition.java
+++ b/pickle-common/src/main/java/com/example/pickle_common/strategy/entity/ProductComposition.java
@@ -1,0 +1,32 @@
+package com.example.pickle_common.strategy.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProductComposition {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int productCompositionId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id")
+    private Product product;
+    private String name;
+    private String code;
+
+    private double ratio;
+    private String themeName;
+    private String categoryName;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_composition_id")
+    private CategoryComposition categoryComposition;
+}

--- a/pickle-common/src/main/java/com/example/pickle_common/strategy/entity/Strategy.java
+++ b/pickle-common/src/main/java/com/example/pickle_common/strategy/entity/Strategy.java
@@ -1,0 +1,22 @@
+package com.example.pickle_common.strategy.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Strategy {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int strategyId;
+
+    private int pbId;
+    private int customerId;
+    private String name;
+
+    @Column(name = "consulting_history_id")
+    private int consultingHistoryId; //아직 ConsultingHistory entity가 없다
+}

--- a/pickle-common/src/main/java/com/example/pickle_common/strategy/repository/CategoryCompositionRepository.java
+++ b/pickle-common/src/main/java/com/example/pickle_common/strategy/repository/CategoryCompositionRepository.java
@@ -1,0 +1,7 @@
+package com.example.pickle_common.strategy.repository;
+
+import com.example.pickle_common.strategy.entity.CategoryComposition;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CategoryCompositionRepository extends JpaRepository<CategoryComposition, Integer> {
+}

--- a/pickle-common/src/main/java/com/example/pickle_common/strategy/repository/ProductCompositionRepository.java
+++ b/pickle-common/src/main/java/com/example/pickle_common/strategy/repository/ProductCompositionRepository.java
@@ -1,0 +1,7 @@
+package com.example.pickle_common.strategy.repository;
+
+import com.example.pickle_common.strategy.entity.ProductComposition;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProductCompositionRepository extends JpaRepository<ProductComposition, Integer> {
+}

--- a/pickle-common/src/main/java/com/example/pickle_common/strategy/repository/ProductRepository.java
+++ b/pickle-common/src/main/java/com/example/pickle_common/strategy/repository/ProductRepository.java
@@ -1,0 +1,10 @@
+package com.example.pickle_common.strategy.repository;
+
+import com.example.pickle_common.strategy.entity.Product;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ProductRepository extends JpaRepository<Product, Integer> {
+    Optional<Product> findByCode(String code);
+}

--- a/pickle-common/src/main/java/com/example/pickle_common/strategy/repository/StrategyRepository.java
+++ b/pickle-common/src/main/java/com/example/pickle_common/strategy/repository/StrategyRepository.java
@@ -1,0 +1,11 @@
+package com.example.pickle_common.strategy.repository;
+
+import com.example.pickle_common.strategy.entity.Strategy;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+
+@Repository
+public interface StrategyRepository extends JpaRepository<Strategy, Integer> {
+
+}

--- a/pickle-common/src/main/java/com/example/pickle_common/strategy/service/StrategyService.java
+++ b/pickle-common/src/main/java/com/example/pickle_common/strategy/service/StrategyService.java
@@ -1,0 +1,89 @@
+package com.example.pickle_common.strategy.service;
+
+import com.example.pickle_common.strategy.dto.CreateStrategyRequestDto;
+import com.example.pickle_common.strategy.dto.CreateStrategyResponseDto;
+import com.example.pickle_common.strategy.entity.CategoryComposition;
+import com.example.pickle_common.strategy.entity.Product;
+import com.example.pickle_common.strategy.entity.ProductComposition;
+import com.example.pickle_common.strategy.entity.Strategy;
+import com.example.pickle_common.strategy.repository.CategoryCompositionRepository;
+import com.example.pickle_common.strategy.repository.ProductCompositionRepository;
+import com.example.pickle_common.strategy.repository.ProductRepository;
+import com.example.pickle_common.strategy.repository.StrategyRepository;
+import com.example.real_common.global.exception.error.*;
+import com.example.real_common.stockEnum.CategoryEnum;
+import com.example.real_common.stockEnum.ThemeEnum;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class StrategyService {
+
+    private final StrategyRepository strategyRepository;
+    private final CategoryCompositionRepository categoryCompositionRepository;
+    private final ProductCompositionRepository productCompositionRepository;
+    private final ProductRepository productRepository;
+//    private final ConsultingHistoryRepository consultingHistoryRepository;
+
+
+    @Transactional
+    public CreateStrategyResponseDto postStrategy(CreateStrategyRequestDto requestDto) {
+        //TODO 로그인 한 사용자만 전략을 생성할 수 있다. (PB)
+
+        //TODO 상담 도메인 구현되면 연결하기 (현재는 1로 고정)
+//        ConsoultingHistory curConsulting =  consultingHistoryRepository
+//                .findbyId(requestDto.getConsultingHistoryId())
+//                .orElseThrow(() -> new NotFoundConsultingHistoryException("consulting history not found with id : " + requestDto.getConsultingHistoryId()));
+//        int curConsultingId = curConsulting.getId();
+        int curConsultingId = 1;
+
+        Strategy strategy = Strategy.builder()
+                .pbId(requestDto.getPbId())
+                .customerId(requestDto.getCustomerId())
+                .name(requestDto.getName())
+                .consultingHistoryId(curConsultingId)
+                .build();
+
+        Strategy savedStrategy = strategyRepository.save(strategy);
+
+        for (CreateStrategyRequestDto.CategoryDto categoryDto : requestDto.getCategoryList()) {
+
+            String curCategory = CategoryEnum.checkName(categoryDto.getCategory());
+
+            CategoryComposition categoryComposition = CategoryComposition.builder()
+                    .strategy(savedStrategy)
+                    .categoryName(curCategory)
+                    .categoryRatio(categoryDto.getCategoryRatio())
+                    .build();
+
+            CategoryComposition createdCategoryComposition = categoryCompositionRepository.save(categoryComposition);
+
+            for (CreateStrategyRequestDto.ProductDto productDTO : categoryDto.getProductList()) {
+
+                String curProductTheme = ThemeEnum.checkName(productDTO.getThemeName());
+
+                Product curProduct = productRepository.findByCode(productDTO.getCode())
+                        .orElseThrow(() -> new NotFoundProductException("not found product : " + productDTO.getCode()));
+
+                ProductComposition productComposition = ProductComposition.builder()
+                        .name(productDTO.getName())
+                        .code(productDTO.getCode())
+                        .ratio(productDTO.getRatio())
+                        .themeName(curProductTheme)
+                        .categoryName(categoryDto.getCategory())
+                        .product(curProduct)
+                        .categoryComposition(createdCategoryComposition)
+                        .build();
+
+                productCompositionRepository.save(productComposition);
+            }
+        }
+
+        int strategyId = savedStrategy.getStrategyId();
+
+        return new CreateStrategyResponseDto(strategyId);
+    }
+}
+

--- a/pickle-common/src/main/resources/application.yml
+++ b/pickle-common/src/main/resources/application.yml
@@ -5,8 +5,8 @@ spring:
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
     username: root
-    url: jdbc:mysql://localhost:3306/customer
-    password: '7643'
+    url: jdbc:mysql://localhost:3306/commonDB
+    password: 'root'
 
   application:
     name: pickle-common  # 서비스 이름

--- a/real-common/src/main/java/com/example/real_common/global/exception/ErrorCode.java
+++ b/real-common/src/main/java/com/example/real_common/global/exception/ErrorCode.java
@@ -7,7 +7,11 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
     CUSTOM_TEST_EXCEPTION(HttpStatus.BAD_REQUEST, "TEST_001", "에러 핸들러 테스트입니다."),
     NOT_FOUND_ACCOUNT_EXCEPTION(HttpStatus.UNAUTHORIZED, "ACCOUNT_001","등록된 계정이 없음"),
-    NOT_FOUND_GROUP_EXCEPTION(HttpStatus.NOT_FOUND,"GROUP_001", "등록된 그룹이 없음");
+    NOT_FOUND_GROUP_EXCEPTION(HttpStatus.NOT_FOUND,"GROUP_001", "등록된 그룹이 없음"),
+    NOT_FOUND_CONSULTING_HISTORY_EXCEPTION(HttpStatus.NOT_FOUND, "CONSULTING_HISTORY_001", "상담 기록을 찾을 수 없음"),
+    NOT_FOUND_CATEGORY_EXCEPTION(HttpStatus.NOT_FOUND, "CATEGORY_001","카테고리를 찾을 없음"),
+    NOT_FOUND_THEME_EXCEPTION(HttpStatus.NOT_FOUND, "THEME_001", "테마를 찾을 수 없음"),
+    NOT_FOUND_PRODUCT_EXCEPTION(HttpStatus.NOT_FOUND, "PRODUCT_001", "상품을 찾을 수 없음");
 
     private final String code;
     private final String message;

--- a/real-common/src/main/java/com/example/real_common/global/exception/GlobalExceptionHandler.java
+++ b/real-common/src/main/java/com/example/real_common/global/exception/GlobalExceptionHandler.java
@@ -2,7 +2,7 @@ package com.example.real_common.global.exception;
 
 import com.example.real_common.global.exception.dto.CommonResponse;
 import com.example.real_common.global.exception.dto.ErrorResponse;
-import com.example.real_common.global.exception.error.CustomTestException;
+import com.example.real_common.global.exception.error.*;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -30,4 +30,82 @@ public class GlobalExceptionHandler {
 
         return new ResponseEntity<>(response, errorCode.getStatus());
     }
+
+    @ExceptionHandler(NotFoundCategoryException.class)
+    protected ResponseEntity<?> handleNotFoundCategoryException(NotFoundCategoryException exception) {
+        log.error("handleNotFoundCategoryException :: ");
+
+        ErrorCode errorCode = ErrorCode.NOT_FOUND_CATEGORY_EXCEPTION;
+
+        ErrorResponse error = ErrorResponse.builder()
+                .status(errorCode.getStatus().value())
+                .message(errorCode.getMessage())
+                .code(errorCode.getCode())
+                .build();
+
+        CommonResponse response = CommonResponse.builder()
+                .success(false)
+                .error(error)
+                .build();
+
+        return new ResponseEntity<>(response, errorCode.getStatus());
+    }
+
+    @ExceptionHandler(NotFoundThemeException.class)
+    protected ResponseEntity<?> handleNotFoundThemeException(NotFoundThemeException exception) {
+        log.error("handleNotFoundThemeException :: ");
+        ErrorCode errorCode = ErrorCode.NOT_FOUND_THEME_EXCEPTION;
+
+        ErrorResponse error = ErrorResponse.builder()
+                .status(errorCode.getStatus().value())
+                .message(errorCode.getMessage())
+                .code(errorCode.getCode())
+                .build();
+
+        CommonResponse response = CommonResponse.builder()
+                .success(false)
+                .error(error)
+                .build();
+
+        return new ResponseEntity<>(response, errorCode.getStatus());
+    }
+
+    @ExceptionHandler(NotFoundProductException.class)
+    protected ResponseEntity<?> handleNotFoundProductException(NotFoundProductException exception) {
+        log.error("handleNotFoundProductException :: ");
+        ErrorCode errorCode = ErrorCode.NOT_FOUND_PRODUCT_EXCEPTION;
+
+        ErrorResponse error = ErrorResponse.builder()
+                .status(errorCode.getStatus().value())
+                .message(errorCode.getMessage())
+                .code(errorCode.getCode())
+                .build();
+
+        CommonResponse response = CommonResponse.builder()
+                .success(false)
+                .error(error)
+                .build();
+
+        return new ResponseEntity<>(response, errorCode.getStatus());
+    }
+
+    @ExceptionHandler(NotFoundConsultingHistoryException.class)
+    protected ResponseEntity<?> handleNotFoundConsultingHistoryException(NotFoundConsultingHistoryException exception) {
+        log.error("handleNotFoundConsultingHistoryException :: ");
+        ErrorCode errorCode = ErrorCode.NOT_FOUND_CONSULTING_HISTORY_EXCEPTION;
+
+        ErrorResponse error = ErrorResponse.builder()
+                .status(errorCode.getStatus().value())
+                .message(errorCode.getMessage())
+                .code(errorCode.getCode())
+                .build();
+
+        CommonResponse response = CommonResponse.builder()
+                .success(false)
+                .error(error)
+                .build();
+
+        return new ResponseEntity<>(response, errorCode.getStatus());
+    }
+
 }

--- a/real-common/src/main/java/com/example/real_common/global/exception/error/NotFoundCategoryException.java
+++ b/real-common/src/main/java/com/example/real_common/global/exception/error/NotFoundCategoryException.java
@@ -1,0 +1,16 @@
+package com.example.real_common.global.exception.error;
+
+public class NotFoundCategoryException extends RuntimeException {
+    public NotFoundCategoryException(String message) {
+        super(message);
+    }
+    public NotFoundCategoryException(String message, Throwable cause) {
+      super(message, cause);
+    }
+    public NotFoundCategoryException(Throwable cause) {
+      super(cause);
+    }
+    public NotFoundCategoryException(){
+      super();
+    }
+}

--- a/real-common/src/main/java/com/example/real_common/global/exception/error/NotFoundConsultingHistoryException.java
+++ b/real-common/src/main/java/com/example/real_common/global/exception/error/NotFoundConsultingHistoryException.java
@@ -1,0 +1,10 @@
+package com.example.real_common.global.exception.error;
+
+public class NotFoundConsultingHistoryException extends RuntimeException {
+    public NotFoundConsultingHistoryException() {super();}
+    public NotFoundConsultingHistoryException(String message) {
+        super(message);
+    }
+    public NotFoundConsultingHistoryException(String message, Throwable cause) {super(message, cause);}
+    public NotFoundConsultingHistoryException(Throwable cause) {super(cause);}
+}

--- a/real-common/src/main/java/com/example/real_common/global/exception/error/NotFoundProductException.java
+++ b/real-common/src/main/java/com/example/real_common/global/exception/error/NotFoundProductException.java
@@ -1,0 +1,16 @@
+package com.example.real_common.global.exception.error;
+
+public class NotFoundProductException extends RuntimeException {
+    public NotFoundProductException(String message) {
+        super(message);
+    }
+    public NotFoundProductException(String message, Throwable cause) {
+        super(message, cause);
+    }
+    public NotFoundProductException(Throwable cause) {
+        super(cause);
+    }
+    public NotFoundProductException() {
+        super();
+    }
+}

--- a/real-common/src/main/java/com/example/real_common/global/exception/error/NotFoundThemeException.java
+++ b/real-common/src/main/java/com/example/real_common/global/exception/error/NotFoundThemeException.java
@@ -1,0 +1,16 @@
+package com.example.real_common.global.exception.error;
+
+public class NotFoundThemeException extends RuntimeException {
+    public NotFoundThemeException(String message) {
+        super(message);
+    }
+    public NotFoundThemeException(String message, Throwable cause) {
+        super(message, cause);
+    }
+    public NotFoundThemeException(Throwable cause) {
+        super(cause);
+    }
+    public NotFoundThemeException() {
+        super();
+    }
+}

--- a/real-common/src/main/java/com/example/real_common/stockEnum/CategoryEnum.java
+++ b/real-common/src/main/java/com/example/real_common/stockEnum/CategoryEnum.java
@@ -1,5 +1,6 @@
 package com.example.real_common.stockEnum;
 
+import com.example.real_common.global.exception.error.NotFoundCategoryException;
 import lombok.Getter;
 
 @Getter
@@ -16,5 +17,15 @@ public enum CategoryEnum {
     CategoryEnum(int id, String name) {
         this.id = id;
         this.name = name;
+    }
+
+    public static String checkName(String categoryName) {
+        for (CategoryEnum categoryEnum : CategoryEnum.values()) {
+            if (categoryEnum.getName().equals(categoryName)) {
+                return categoryEnum.getName();
+            }
+        }
+
+        throw new NotFoundCategoryException("category not found : " + categoryName);
     }
 }

--- a/real-common/src/main/java/com/example/real_common/stockEnum/ThemeEnum.java
+++ b/real-common/src/main/java/com/example/real_common/stockEnum/ThemeEnum.java
@@ -1,5 +1,6 @@
 package com.example.real_common.stockEnum;
 
+import com.example.real_common.global.exception.error.NotFoundThemeException;
 import lombok.Getter;
 
 @Getter
@@ -107,5 +108,14 @@ public enum ThemeEnum {
         this.categoryId = categoryId;
         this.name = name;
         this.categoryName = categoryName;
+    }
+
+    public static String checkName(String themeName) {
+        for (ThemeEnum themeEnum : ThemeEnum.values()) {
+            if (themeEnum.getName().equals(themeName)) {
+                return themeName;
+            }
+        }
+        throw new NotFoundThemeException("theme not found : " + themeName);
     }
 }


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가
- [x] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feature/PICKLE-74-pb-create-strategy -> develop

### 변경 사항
- 전략 생성 api 구현
- Product, Category, Theme, ConsultingHistory NotFound 예외 클래스 생성
   - 핸들러 추가
- 공통 모듈 속 category, theme Enum에 주어진 String이 존재하는지 체크하는 메서드 추가

### 추후 보완할 부분
- 사용자 로그인 체크
- 상담 서비스 구현 후 상담 기록 존재 여부 확인 로직 추가 필요

### 테스트 결과
![image](https://github.com/user-attachments/assets/3fa110eb-8f85-4edc-8035-75751a2fe9b1)
![image](https://github.com/user-attachments/assets/73a1b46b-9e8d-4390-a433-7703ce7f5dc2)
![image](https://github.com/user-attachments/assets/a3d4f9fc-a4a5-4d75-8a46-a7fca61f2984)
![image](https://github.com/user-attachments/assets/3a4f8dff-4298-403b-aa9c-60a08d587180)


