### PR TITLE
Feature/pickle 77 strategy 조회 기능 구현

### DIFF
--- a/pickle-common/src/main/java/com/example/pickle_common/PickleCommonApplication.java
+++ b/pickle-common/src/main/java/com/example/pickle_common/PickleCommonApplication.java
@@ -2,7 +2,9 @@ package com.example.pickle_common;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication(scanBasePackages = {"com.example.pickle_common", "com.example.real_common"})
 public class PickleCommonApplication {
 

--- a/pickle-common/src/main/java/com/example/pickle_common/strategy/controller/StrategyController.java
+++ b/pickle-common/src/main/java/com/example/pickle_common/strategy/controller/StrategyController.java
@@ -2,6 +2,7 @@ package com.example.pickle_common.strategy.controller;
 
 import com.example.pickle_common.strategy.dto.CreateStrategyRequestDto;
 import com.example.pickle_common.strategy.dto.CreateStrategyResponseDto;
+import com.example.pickle_common.strategy.dto.ReadStrategyResponseDto;
 import com.example.pickle_common.strategy.service.StrategyService;
 import com.example.real_common.global.common.CommonResDto;
 import jakarta.validation.Valid;
@@ -10,10 +11,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RestController
@@ -25,8 +23,14 @@ public class StrategyController {
     private final StrategyService strategyService;
 
     @PostMapping
-    public ResponseEntity<CommonResDto<?>> postStrategy(@RequestBody @Valid CreateStrategyRequestDto createStrategyRequestDto) {
+    public ResponseEntity<CommonResDto<?>> createStrategy(@RequestBody @Valid CreateStrategyRequestDto createStrategyRequestDto) {
         CreateStrategyResponseDto responseDto = strategyService.postStrategy(createStrategyRequestDto);
         return ResponseEntity.status(HttpStatus.CREATED).body(new CommonResDto<>(1, "전략 생성 성공", responseDto));
+    }
+
+    @GetMapping
+    public ResponseEntity<CommonResDto<?>> readStrategy() {
+        ReadStrategyResponseDto result = strategyService.readStrategy();
+        return ResponseEntity.status(HttpStatus.OK).body(new CommonResDto<>(1, "전략 조회 성공", result));
     }
 }

--- a/pickle-common/src/main/java/com/example/pickle_common/strategy/dto/ReadStrategyResponseDto.java
+++ b/pickle-common/src/main/java/com/example/pickle_common/strategy/dto/ReadStrategyResponseDto.java
@@ -1,0 +1,32 @@
+package com.example.pickle_common.strategy.dto;
+
+import com.example.real_common.global.BaseTimeEntity;
+import com.example.real_common.stockEnum.CategoryEnum;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.Date;
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ReadStrategyResponseDto {
+    private List<StrategyInfoDto> strategyList;
+
+    @Builder
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class StrategyInfoDto {
+        private String name;
+        private String pbName;
+        private String pbBranchOffice;
+        private LocalDateTime createdAt;
+        private List<String> categoryComposition;
+    }
+}

--- a/pickle-common/src/main/java/com/example/pickle_common/strategy/dto/RestClientDto.java
+++ b/pickle-common/src/main/java/com/example/pickle_common/strategy/dto/RestClientDto.java
@@ -1,0 +1,15 @@
+package com.example.pickle_common.strategy.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+public class RestClientDto {
+
+    @Getter
+    public static class PbInfoRequestDto {
+        @NotBlank
+        private String name;
+        @NotBlank
+        private String branchOffice;
+    }
+}

--- a/pickle-common/src/main/java/com/example/pickle_common/strategy/entity/Strategy.java
+++ b/pickle-common/src/main/java/com/example/pickle_common/strategy/entity/Strategy.java
@@ -1,5 +1,6 @@
 package com.example.pickle_common.strategy.entity;
 
+import com.example.real_common.global.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -8,7 +9,7 @@ import lombok.*;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-public class Strategy {
+public class Strategy extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private int strategyId;

--- a/pickle-common/src/main/java/com/example/pickle_common/strategy/repository/CategoryCompositionRepository.java
+++ b/pickle-common/src/main/java/com/example/pickle_common/strategy/repository/CategoryCompositionRepository.java
@@ -3,5 +3,8 @@ package com.example.pickle_common.strategy.repository;
 import com.example.pickle_common.strategy.entity.CategoryComposition;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface CategoryCompositionRepository extends JpaRepository<CategoryComposition, Integer> {
+    List<CategoryComposition> findByStrategy_strategyId(Integer strategyId);
 }

--- a/pickle-common/src/main/java/com/example/pickle_common/strategy/repository/StrategyRepository.java
+++ b/pickle-common/src/main/java/com/example/pickle_common/strategy/repository/StrategyRepository.java
@@ -4,8 +4,10 @@ import com.example.pickle_common.strategy.entity.Strategy;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 
 @Repository
 public interface StrategyRepository extends JpaRepository<Strategy, Integer> {
-
+    List<Strategy> findAllByCustomerId(Integer customerId);
 }

--- a/pickle-common/src/main/java/com/example/pickle_common/strategy/service/StrategyService.java
+++ b/pickle-common/src/main/java/com/example/pickle_common/strategy/service/StrategyService.java
@@ -2,6 +2,8 @@ package com.example.pickle_common.strategy.service;
 
 import com.example.pickle_common.strategy.dto.CreateStrategyRequestDto;
 import com.example.pickle_common.strategy.dto.CreateStrategyResponseDto;
+import com.example.pickle_common.strategy.dto.ReadStrategyResponseDto;
+import com.example.pickle_common.strategy.dto.RestClientDto;
 import com.example.pickle_common.strategy.entity.CategoryComposition;
 import com.example.pickle_common.strategy.entity.Product;
 import com.example.pickle_common.strategy.entity.ProductComposition;
@@ -11,11 +13,16 @@ import com.example.pickle_common.strategy.repository.ProductCompositionRepositor
 import com.example.pickle_common.strategy.repository.ProductRepository;
 import com.example.pickle_common.strategy.repository.StrategyRepository;
 import com.example.real_common.global.exception.error.*;
+import com.example.real_common.global.restClient.CustomRestClient;
 import com.example.real_common.stockEnum.CategoryEnum;
 import com.example.real_common.stockEnum.ThemeEnum;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -30,7 +37,9 @@ public class StrategyService {
 
     @Transactional
     public CreateStrategyResponseDto postStrategy(CreateStrategyRequestDto requestDto) {
-        //TODO 로그인 한 사용자만 전략을 생성할 수 있다. (PB)
+        //TODO 로그인 한 사용자만 전략을 생성할 수 있다. (PB 혹은 고객)
+        // 고객 : 리밸런싱할 때 커스텀 전략 생성 가능 (이 경우 고객id만 들어감)
+        // PB : 상담할 때 고객을 위한 전략 생성 (이 경우 고객id, pbId 들어감)
 
         //TODO 상담 도메인 구현되면 연결하기 (현재는 1로 고정)
 //        ConsoultingHistory curConsulting =  consultingHistoryRepository
@@ -84,6 +93,40 @@ public class StrategyService {
         int strategyId = savedStrategy.getStrategyId();
 
         return new CreateStrategyResponseDto(strategyId);
+    }
+
+    public ReadStrategyResponseDto readStrategy() {
+        //TODO 로그인한 user가 고객일 경우를 체크, 정보 가져오기
+        int customerId = 1; //임시
+
+        List<Strategy> existStrategies = strategyRepository.findAllByCustomerId(customerId);
+
+        RestClient restClient = CustomRestClient.connectPbRestClient("/inner");
+
+        List<ReadStrategyResponseDto.StrategyInfoDto> strategyList = existStrategies.stream()
+                .map(existStrategy -> {
+                    RestClientDto.PbInfoRequestDto pbInfo = restClient.get()
+                            .uri("/{pbId}", existStrategy.getPbId())
+                            .accept(MediaType.APPLICATION_JSON)
+                            .retrieve()
+                            .body(RestClientDto.PbInfoRequestDto.class);
+
+                    List<String> curCategoryComposition = categoryCompositionRepository.findByStrategy_strategyId(existStrategy.getStrategyId()).stream()
+                            .map(CategoryComposition::getCategoryName).toList();
+
+                    return ReadStrategyResponseDto.StrategyInfoDto.builder()
+                            .name(existStrategy.getName())
+                            .pbName(pbInfo.getName())
+                            .pbBranchOffice(pbInfo.getBranchOffice())
+                            .createdAt(existStrategy.getCreatedAt())
+                            .categoryComposition(curCategoryComposition)
+                            .build();
+                }).toList();
+
+
+        return ReadStrategyResponseDto.builder()
+                .strategyList(strategyList)
+                .build();
     }
 }
 

--- a/pickle-pb/src/main/java/com/example/pickle_pb/pb/auth/config/AuthConfig.java
+++ b/pickle-pb/src/main/java/com/example/pickle_pb/pb/auth/config/AuthConfig.java
@@ -36,7 +36,7 @@ public class AuthConfig {
                 .csrf(csrf -> csrf.disable())  // CSRF 보호 비활성화
                 .cors(cors -> cors.disable())  // CORS 보호 비활성화
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/pickle-pb/join", "/pickle-pb/token", "pickle-pb/validate", "pickle-pb/inner/**").permitAll() // 특정 경로 허용
+                        .requestMatchers("/pickle-pb/api/join", "/pickle-pb/api/token", "pickle-pb/api/validate", "pickle-pb/inner/**").permitAll() // 특정 경로 허용
                                 .requestMatchers("/pickle-pb/api/**").authenticated()
                 )
                 .addFilterBefore(new JwtAuthenticationFilter(jwtService), UsernamePasswordAuthenticationFilter.class)

--- a/pickle-pb/src/main/java/com/example/pickle_pb/pb/auth/config/AuthConfig.java
+++ b/pickle-pb/src/main/java/com/example/pickle_pb/pb/auth/config/AuthConfig.java
@@ -36,7 +36,7 @@ public class AuthConfig {
                 .csrf(csrf -> csrf.disable())  // CSRF 보호 비활성화
                 .cors(cors -> cors.disable())  // CORS 보호 비활성화
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/pickle-pb/join", "/pickle-pb/token", "pickle-pb/validate").permitAll() // 특정 경로 허용
+                        .requestMatchers("/pickle-pb/join", "/pickle-pb/token", "pickle-pb/validate", "pickle-pb/inner/**").permitAll() // 특정 경로 허용
                                 .requestMatchers("/pickle-pb/api/**").authenticated()
                 )
                 .addFilterBefore(new JwtAuthenticationFilter(jwtService), UsernamePasswordAuthenticationFilter.class)

--- a/pickle-pb/src/main/java/com/example/pickle_pb/pb/controller/PbController.java
+++ b/pickle-pb/src/main/java/com/example/pickle_pb/pb/controller/PbController.java
@@ -3,6 +3,7 @@ package com.example.pickle_pb.pb.controller;
 
 import com.example.pickle_pb.pb.dto.PbJoinDto;
 import com.example.pickle_pb.pb.dto.PbLoginDto;
+import com.example.pickle_pb.pb.dto.ReadPbResponseDto;
 import com.example.pickle_pb.pb.service.PbService;
 import com.example.real_common.global.common.CommonResDto;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,11 +13,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @Configuration
@@ -55,5 +52,11 @@ public class PbController {
     public ResponseEntity<CommonResDto<?>> validateToken(@RequestParam("token") String token) {
         pbService.validateToken(token);
         return ResponseEntity.status(HttpStatus.CREATED).body(new CommonResDto<>(1, "토큰 검증 완료", "토큰 검증완료"));
+    }
+
+    @GetMapping("/pickle-pb/inner/{pbId}")
+    public ResponseEntity<?> getPbById(@PathVariable("pbId") Integer pbId) {
+        ReadPbResponseDto.InfoForStrategyDto result = pbService.getPbById(pbId);
+        return ResponseEntity.status(HttpStatus.OK).body(result);
     }
 }

--- a/pickle-pb/src/main/java/com/example/pickle_pb/pb/dto/ReadPbResponseDto.java
+++ b/pickle-pb/src/main/java/com/example/pickle_pb/pb/dto/ReadPbResponseDto.java
@@ -1,0 +1,15 @@
+package com.example.pickle_pb.pb.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+public class ReadPbResponseDto {
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class InfoForStrategyDto {
+        private String name;
+        private String branchOffice;
+    }
+}

--- a/pickle-pb/src/main/java/com/example/pickle_pb/pb/service/PbService.java
+++ b/pickle-pb/src/main/java/com/example/pickle_pb/pb/service/PbService.java
@@ -2,9 +2,11 @@ package com.example.pickle_pb.pb.service;
 
 import com.example.pickle_pb.pb.auth.JwtService;
 import com.example.pickle_pb.pb.dto.PbJoinDto;
+import com.example.pickle_pb.pb.dto.ReadPbResponseDto;
 import com.example.pickle_pb.pb.entity.Pb;
 import com.example.pickle_pb.pb.entity.PbPassword;
 import com.example.pickle_pb.pb.repository.PbRepository;
+import com.example.real_common.global.exception.error.NotFoundAccountException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -51,5 +53,15 @@ public class PbService {
 
     public void validateToken(String token) {
         jwtService.validateToken(token);
+    }
+
+    public ReadPbResponseDto.InfoForStrategyDto getPbById(Integer pbId) {
+        Pb existPb = pbRepository.findById(Long.valueOf(pbId))
+                .orElseThrow(() -> new NotFoundAccountException("not found pb by id : " + pbId));
+
+        return ReadPbResponseDto.InfoForStrategyDto.builder()
+                .name(existPb.getUsername())
+                .branchOffice(existPb.getBranchOffice())
+                .build();
     }
 }

--- a/real-common/src/main/java/com/example/real_common/global/restClient/CustomRestClient.java
+++ b/real-common/src/main/java/com/example/real_common/global/restClient/CustomRestClient.java
@@ -1,0 +1,17 @@
+package com.example.real_common.global.restClient;
+
+import org.springframework.web.client.RestClient;
+
+public class CustomRestClient {
+
+    private static final String baseUrl = "http://localhost";
+
+    public static RestClient connectPbRestClient(String path) {
+        return RestClient.builder()
+                .baseUrl(baseUrl + ":8002/pickle-pb" + path)
+                .build();
+    }
+
+//    public static RestClient connectCustomerRestClient(String path) {}
+//    public static RestClient connectCommonRestClient(String path) {}
+}

--- a/real-common/src/main/java/com/example/real_common/stockEnum/CategoryEnum.java
+++ b/real-common/src/main/java/com/example/real_common/stockEnum/CategoryEnum.java
@@ -9,7 +9,7 @@ public enum CategoryEnum {
     GLOBAL(2, "해외"),
     BOND(3, "채권"),
     MATERIAL(4, "원자재"),
-    ETF(5, "채권");
+    ETF(5, "ETF");
 
     private final int id;
     private final String name;


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가

### 반영 브랜치
feature/PICKLE-77-cus-read-strategy -> develop

### 변경 사항
- 내부 통신 용으로 get pickle-common/api/strategy api 구현
  - CommonResDto으로 감싸면 common service 안에서 데이터를 역직렬화 하기가 까다로워서 아래처럼 response를 주게 구현했습니다
  ```
  {
    "name": "pb1",
    "branchOffice": "강남점"
    }
  ```
  
- 공통 모듈에 RestClient 인스턴스 생성용 클래스 구현
- 전략 조회 api 구현
  - 로그인 한 고객에게만 필요한 기능이기 때문에 추후 고객 인증 여부 구현 필요합니다

```
{
    "code": 1,
    "message": "전략 조회 성공",
    "data": {
        "strategyList": [
            {
                "name": "전략생성테스트",
                "pbName": "pb1",
                "pbBranchOffice": "강남점",
                "createdAt": "2024-09-02T11:27:36",
                "categoryComposition": [
                    "국내",
                    "해외"
                ]
            },
            {
                "name": "전략생성테스트2",
                "pbName": "pb1",
                "pbBranchOffice": "강남점",
                "createdAt": "2024-09-01T11:27:29",
                "categoryComposition": [
                    "국내",
                    "해외"
                ]
            },
            {
                "name": "전략생성테스트3",
                "pbName": "pb1",
                "pbBranchOffice": "강남점",
                "createdAt": "2024-09-01T11:27:39",
                "categoryComposition": [
                    "국내",
                    "해외"
                ]
            }
        ]
    }
}
```
### 테스트 결과
![image](https://github.com/user-attachments/assets/e9eada9b-c1c4-4e18-9a85-9449181cb039)

