### PR TITLE
Feature/pickle 113 내 전략 생성 기능 추가

### DIFF
--- a/pickle-common/src/main/java/com/example/pickle_common/strategy/controller/InnerStrategyController.java
+++ b/pickle-common/src/main/java/com/example/pickle_common/strategy/controller/InnerStrategyController.java
@@ -1,0 +1,25 @@
+package com.example.pickle_common.strategy.controller;
+
+import com.example.pickle_common.strategy.dto.RestClientDto;
+import com.example.pickle_common.strategy.service.StrategyService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/pickle-common/inner/strategy")
+public class InnerStrategyController {
+
+    private final StrategyService strategyService;
+
+    @GetMapping("/{strategyId}")
+    public ResponseEntity<?> getStrategy(@PathVariable int strategyId) {
+        RestClientDto.ReadStrategyResponseDto result = strategyService.getStrategy(strategyId);
+        return ResponseEntity.status(HttpStatus.OK).body(result);
+    }
+}

--- a/pickle-common/src/main/java/com/example/pickle_common/strategy/dto/RestClientDto.java
+++ b/pickle-common/src/main/java/com/example/pickle_common/strategy/dto/RestClientDto.java
@@ -1,7 +1,12 @@
 package com.example.pickle_common.strategy.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 public class RestClientDto {
 
@@ -11,5 +16,15 @@ public class RestClientDto {
         private String name;
         @NotBlank
         private String branchOffice;
+    }
+
+    @Builder
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class ReadStrategyResponseDto {
+        private String name;
+        private int strategyId;
+        private List<ReadDetailStrategyResponseDto.CategoryDto> categoryList;
     }
 }

--- a/pickle-customer/src/main/java/com/example/pickle_customer/mystrategy/dto/CreateMyStrategyDto.java
+++ b/pickle-customer/src/main/java/com/example/pickle_customer/mystrategy/dto/CreateMyStrategyDto.java
@@ -1,0 +1,27 @@
+package com.example.pickle_customer.mystrategy.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class CreateMyStrategyDto {
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class Request {
+        private int accountId;
+        private int selectedStrategyId;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class Response {
+        private int createdMyStrategyId;
+    }
+
+}

--- a/pickle-customer/src/main/java/com/example/pickle_customer/mystrategy/dto/RestClientDto.java
+++ b/pickle-customer/src/main/java/com/example/pickle_customer/mystrategy/dto/RestClientDto.java
@@ -1,0 +1,42 @@
+package com.example.pickle_customer.mystrategy.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+public class RestClientDto {
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class ReadStrategyResponseDto {
+        private String name;
+        private int strategyId;
+        private List<CategoryDto> categoryList;
+    }
+
+    @Builder
+    @AllArgsConstructor
+    @Getter
+    @NoArgsConstructor
+    public static class CategoryDto {
+        private String categoryName;
+        private double categoryRatio;
+        private List<ProductDto> productList;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    @NoArgsConstructor
+    public static class ProductDto {
+        private String code;
+        private String name;
+        private String themeName;
+        private double ratio;
+    }
+}

--- a/pickle-customer/src/main/java/com/example/pickle_customer/mystrategy/entity/MyStrategy.java
+++ b/pickle-customer/src/main/java/com/example/pickle_customer/mystrategy/entity/MyStrategy.java
@@ -1,0 +1,27 @@
+package com.example.pickle_customer.mystrategy.entity;
+
+import com.example.pickle_customer.entity.Account;
+import com.example.real_common.global.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Builder
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class MyStrategy extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "my_strategy_id")
+    private int Id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "account_id")
+    private Account account;
+
+    @Column(name = "selected_strategy")
+    private int selectedStrategyId;
+
+    private String name;
+}

--- a/pickle-customer/src/main/java/com/example/pickle_customer/mystrategy/entity/MyStrategyCategoryComposition.java
+++ b/pickle-customer/src/main/java/com/example/pickle_customer/mystrategy/entity/MyStrategyCategoryComposition.java
@@ -1,0 +1,23 @@
+package com.example.pickle_customer.mystrategy.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Builder
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class MyStrategyCategoryComposition {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "category_composition_id")
+    private int id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "my_strategy_id")
+    private MyStrategy myStrategy;
+
+    private String categoryName;
+    private double categoryRatio;
+}

--- a/pickle-customer/src/main/java/com/example/pickle_customer/mystrategy/entity/MyStrategyProductComposition.java
+++ b/pickle-customer/src/main/java/com/example/pickle_customer/mystrategy/entity/MyStrategyProductComposition.java
@@ -1,0 +1,29 @@
+package com.example.pickle_customer.mystrategy.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MyStrategyProductComposition {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "product_composition_id")
+    private int id;
+
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_composition_id")
+    private MyStrategyCategoryComposition categoryComposition;
+
+    private String productCode;
+    private String productName;
+    private String categoryName;
+    private String themeName;
+    private double ratio;
+}

--- a/pickle-customer/src/main/java/com/example/pickle_customer/mystrategy/repository/CategoryCompositionRepository.java
+++ b/pickle-customer/src/main/java/com/example/pickle_customer/mystrategy/repository/CategoryCompositionRepository.java
@@ -1,0 +1,7 @@
+package com.example.pickle_customer.mystrategy.repository;
+
+import com.example.pickle_customer.mystrategy.entity.MyStrategyCategoryComposition;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CategoryCompositionRepository extends JpaRepository<MyStrategyCategoryComposition, Integer> {
+}

--- a/pickle-customer/src/main/java/com/example/pickle_customer/mystrategy/repository/MyStrategyRepository.java
+++ b/pickle-customer/src/main/java/com/example/pickle_customer/mystrategy/repository/MyStrategyRepository.java
@@ -1,0 +1,7 @@
+package com.example.pickle_customer.mystrategy.repository;
+
+import com.example.pickle_customer.mystrategy.entity.MyStrategy;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MyStrategyRepository extends JpaRepository<MyStrategy, Integer> {
+}

--- a/pickle-customer/src/main/java/com/example/pickle_customer/mystrategy/repository/ProductCompositionRepository.java
+++ b/pickle-customer/src/main/java/com/example/pickle_customer/mystrategy/repository/ProductCompositionRepository.java
@@ -1,0 +1,7 @@
+package com.example.pickle_customer.mystrategy.repository;
+
+import com.example.pickle_customer.mystrategy.entity.MyStrategyProductComposition;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProductCompositionRepository extends JpaRepository<MyStrategyProductComposition, Integer> {
+}

--- a/pickle-customer/src/main/java/com/example/pickle_customer/mystrategy/service/MyStrategyService.java
+++ b/pickle-customer/src/main/java/com/example/pickle_customer/mystrategy/service/MyStrategyService.java
@@ -1,0 +1,83 @@
+package com.example.pickle_customer.mystrategy.service;
+
+import com.example.pickle_customer.entity.Account;
+import com.example.pickle_customer.mystrategy.dto.CreateMyStrategyDto;
+import com.example.pickle_customer.mystrategy.dto.RestClientDto;
+import com.example.pickle_customer.mystrategy.entity.MyStrategyCategoryComposition;
+import com.example.pickle_customer.mystrategy.entity.MyStrategy;
+import com.example.pickle_customer.mystrategy.entity.MyStrategyProductComposition;
+import com.example.pickle_customer.mystrategy.repository.CategoryCompositionRepository;
+import com.example.pickle_customer.mystrategy.repository.MyStrategyRepository;
+import com.example.pickle_customer.mystrategy.repository.ProductCompositionRepository;
+import com.example.pickle_customer.repository.AccountRepository;
+import com.example.real_common.global.exception.error.NotFoundAccountException;
+import com.example.real_common.global.restClient.CustomRestClient;
+import com.example.real_common.stockEnum.CategoryEnum;
+import com.example.real_common.stockEnum.ThemeEnum;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+
+@Service
+@RequiredArgsConstructor
+public class MyStrategyService {
+    private final MyStrategyRepository myStrategyRepository;
+    private final CategoryCompositionRepository categoryCompositionRepository;
+    private final ProductCompositionRepository productCompositionRepository;
+    private final AccountRepository accountRepository;
+
+    @Transactional
+    public CreateMyStrategyDto.Response createMyStrategy(CreateMyStrategyDto.Request request) {
+        RestClient restClient = CustomRestClient.connectCommon("/inner/strategy");
+
+        RestClientDto.ReadStrategyResponseDto selectedStrategy = restClient.get()
+                .uri("/{strategyId}", request.getSelectedStrategyId())
+                .retrieve()
+                .body(RestClientDto.ReadStrategyResponseDto.class);
+
+        Account account = accountRepository.findById(request.getAccountId())
+                .orElseThrow(() -> new NotFoundAccountException("not found account" + request.getAccountId()));
+
+        // 이제 찐 저장
+        MyStrategy myStrategy = MyStrategy.builder()
+                .account(account)
+                .selectedStrategyId(request.getSelectedStrategyId())
+                .name(selectedStrategy.getName())
+                .build();
+
+        MyStrategy savedMyStrategy = myStrategyRepository.save(myStrategy);
+
+        for (RestClientDto.CategoryDto categoryDto : selectedStrategy.getCategoryList()) {
+            String curCategory = CategoryEnum.checkName(categoryDto.getCategoryName());
+
+            MyStrategyCategoryComposition categoryComposition = MyStrategyCategoryComposition.builder()
+                    .myStrategy(savedMyStrategy)
+                    .categoryName(curCategory)
+                    .categoryRatio(categoryDto.getCategoryRatio())
+                    .build();
+
+            MyStrategyCategoryComposition savedCategoryComposition = categoryCompositionRepository.save(categoryComposition);
+
+            for (RestClientDto.ProductDto productDto : categoryDto.getProductList()) {
+                String curProductTheme = ThemeEnum.checkName(productDto.getThemeName());
+
+                MyStrategyProductComposition productComposition = MyStrategyProductComposition.builder()
+                        .productCode(productDto.getCode())
+                        .productName(productDto.getName())
+                        .categoryName(curCategory)
+                        .ratio(productDto.getRatio())
+                        .categoryComposition(savedCategoryComposition)
+                        .themeName(curProductTheme)
+                        .build();
+
+                productCompositionRepository.save(productComposition);
+            }
+        }
+
+        return CreateMyStrategyDto.Response.builder()
+                .createdMyStrategyId(savedMyStrategy.getId())
+                .build();
+    }
+
+}

--- a/real-common/src/main/java/com/example/real_common/global/restClient/CustomRestClient.java
+++ b/real-common/src/main/java/com/example/real_common/global/restClient/CustomRestClient.java
@@ -6,12 +6,16 @@ public class CustomRestClient {
 
     private static final String baseUrl = "http://localhost";
 
-    public static RestClient connectPbRestClient(String path) {
+    public static RestClient connectPb(String path) {
         return RestClient.builder()
                 .baseUrl(baseUrl + ":8002/pickle-pb" + path)
                 .build();
     }
 
+    public static RestClient connectCommon(String path) {
+        return RestClient.builder()
+                .baseUrl(baseUrl + ":8004/pickle-common" + path)
+                .build();
+    }
 //    public static RestClient connectCustomerRestClient(String path) {}
-//    public static RestClient connectCommonRestClient(String path) {}
 }


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가

### 반영 브랜치
feature/PICKLE-113-create-my-strategy-from-common -> develop

### 변경 사항
- 내부 통신용 전략 조회 /inner/strategy/{strategyId} 구현
   - common 모듈과 통신하는 RestClient 생성 메서드 추가
- 주문 시 사용될 내 전략 생성 서비스 구현

### 테스트 결과
db에도 제대로 반영되는 것 확인하였습니다.
![image](https://github.com/user-attachments/assets/cfcdb186-8bfb-4c00-9983-8bb1c41dca9f)
