### PR TITLE
feat: 상담에 필요한 Entity 및 Enum 생성

### DIFF
--- a/pickle-common/src/main/java/com/example/pickle_common/consulting/controller/CustomerConsultingController.java
+++ b/pickle-common/src/main/java/com/example/pickle_common/consulting/controller/CustomerConsultingController.java
@@ -1,0 +1,13 @@
+package com.example.pickle_common.consulting.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/pickle-common/consulting/customer")
+@Validated
+@RequiredArgsConstructor
+public class CustomerConsultingController {
+}

--- a/pickle-common/src/main/java/com/example/pickle_common/consulting/controller/PbConsultingController.java
+++ b/pickle-common/src/main/java/com/example/pickle_common/consulting/controller/PbConsultingController.java
@@ -1,0 +1,13 @@
+package com.example.pickle_common.consulting.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/pickle-common/consulting/pb")
+@Validated
+@RequiredArgsConstructor
+public class PbConsultingController {
+}

--- a/pickle-common/src/main/java/com/example/pickle_common/consulting/entity/AnswerType.java
+++ b/pickle-common/src/main/java/com/example/pickle_common/consulting/entity/AnswerType.java
@@ -1,0 +1,27 @@
+package com.example.pickle_common.consulting.entity;
+
+public enum AnswerType {
+    NONE(0),
+    OPTION_ONE(1),
+    OPTION_TWO(2),
+    OPTION_THREE(3);
+
+    private final int value;
+
+    AnswerType(int value) {
+        this.value = value;
+    }
+
+    public int getValue() {
+        return value;
+    }
+
+    public static AnswerType fromValue(int value) {
+        for (AnswerType type : AnswerType.values()) {
+            if (type.getValue() == value) {
+                return type;
+            }
+        }
+        throw new IllegalArgumentException("Invalid value for AnswerType: " + value);
+    }
+}

--- a/pickle-common/src/main/java/com/example/pickle_common/consulting/entity/ConsultingConfirmDate.java
+++ b/pickle-common/src/main/java/com/example/pickle_common/consulting/entity/ConsultingConfirmDate.java
@@ -1,0 +1,32 @@
+package com.example.pickle_common.consulting.entity;
+
+import com.example.real_common.global.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ConsultingConfirmDate extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "consulting_confirm_date_id")
+    private int id;
+
+    @OneToOne
+    @JoinColumn(name = "consulting_history_id")
+    private ConsultingHistory consultingHistory;
+
+    private int customerId;
+    private int pbId;
+
+    private Date date;
+}

--- a/pickle-common/src/main/java/com/example/pickle_common/consulting/entity/ConsultingHistory.java
+++ b/pickle-common/src/main/java/com/example/pickle_common/consulting/entity/ConsultingHistory.java
@@ -1,0 +1,49 @@
+package com.example.pickle_common.consulting.entity;
+
+import com.example.pickle_common.strategy.entity.Strategy;
+import com.example.real_common.global.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ConsultingHistory extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "conulting_history_id")
+    private int id;
+
+    private int pbId;
+    private String pbName;
+    private String pbBranchOffice;
+
+    private int customerId;
+    private String customerName;
+
+
+    private String roomId;
+    private String pbImage;
+
+    @Enumerated(EnumType.STRING)
+    private String consultingStatusName;
+
+    // 양방향이 꼭 필요한지 확인을 해봐야한다.
+    // OneToOne 양방향 매핑에서는 fetch LAZY 적용이 안되는 상황이 많다.
+    @OneToOne(mappedBy = "consultingHistory", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private RequestLetter requestLetter;
+
+    @OneToOne(mappedBy = "consultingHistory", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private ConsultingConfirmDate consultingConfirmDate;
+
+    // 전략과 양방향 매핑
+    @OneToOne(mappedBy = "consultingHistory", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private Strategy strategy;
+}

--- a/pickle-common/src/main/java/com/example/pickle_common/consulting/entity/ConsultingRejectInfo.java
+++ b/pickle-common/src/main/java/com/example/pickle_common/consulting/entity/ConsultingRejectInfo.java
@@ -1,0 +1,25 @@
+package com.example.pickle_common.consulting.entity;
+
+import com.example.real_common.global.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ConsultingRejectInfo extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "consulting_reject_info_id")
+    private int id;
+
+    @OneToOne(mappedBy = "request_letter_id")
+    private RequestLetter requestLetter;
+    private String content;
+
+}

--- a/pickle-common/src/main/java/com/example/pickle_common/consulting/entity/ConsultingStatusEnum.java
+++ b/pickle-common/src/main/java/com/example/pickle_common/consulting/entity/ConsultingStatusEnum.java
@@ -1,0 +1,31 @@
+package com.example.pickle_common.consulting.entity;
+
+import com.example.real_common.global.exception.error.NotFoundConsultingStatusException;
+import lombok.Getter;
+
+@Getter
+public enum ConsultingStatusEnum {
+    ETC(0, "기타"),
+    REQUESTED(1, "상담요청"),
+    ACCEPTED(2, "상담수락"),
+    REJECTED(3, "상담거절"),
+    COMPLETED(4, "상담완료"),
+    NO_SHOW(5, "상담노쇼"),;
+
+    private final int id;
+    private final String name;
+
+    private ConsultingStatusEnum(int id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public static ConsultingStatusEnum fromId(int id) {
+        for (ConsultingStatusEnum status : ConsultingStatusEnum.values()) {
+            if (status.getId() == id) {
+                return status;
+            }
+        }
+        throw new NotFoundConsultingStatusException("Invalid id for ConsultingStatusEnum: " + id);
+    }
+}

--- a/pickle-common/src/main/java/com/example/pickle_common/consulting/entity/RequestLetter.java
+++ b/pickle-common/src/main/java/com/example/pickle_common/consulting/entity/RequestLetter.java
@@ -1,0 +1,52 @@
+package com.example.pickle_common.consulting.entity;
+
+import com.example.real_common.global.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RequestLetter extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "request_letter_id")
+    private int id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "consulting_history_id")
+    private ConsultingHistory consultingHistory;
+
+    @OneToOne(fetch = FetchType.LAZY, optional = true)
+    @JoinColumn(name = "consulting_reject_info_id", nullable = true)
+    private ConsultingRejectInfo consultingRejectInfo;
+
+    private int customerId;
+    private int customerAge;
+    private String customerGender;
+    private String customerJob;
+
+    private String request;
+    @Enumerated(EnumType.STRING)
+    private AnswerType answer1;
+
+    @Enumerated(EnumType.STRING)
+    private AnswerType answer2;
+
+    @Enumerated(EnumType.STRING)
+    private AnswerType answer3;
+
+    @Enumerated(EnumType.STRING)
+    private AnswerType answer4;
+
+    private long availableInvestAmount;
+    private long desiredInvestAmount;
+
+    private String referenceFileUrl;
+}

--- a/real-common/src/main/java/com/example/real_common/global/exception/ErrorCode.java
+++ b/real-common/src/main/java/com/example/real_common/global/exception/ErrorCode.java
@@ -11,7 +11,8 @@ public enum ErrorCode {
     NOT_FOUND_CONSULTING_HISTORY_EXCEPTION(HttpStatus.NOT_FOUND, "CONSULTING_HISTORY_001", "상담 기록을 찾을 수 없음"),
     NOT_FOUND_CATEGORY_EXCEPTION(HttpStatus.NOT_FOUND, "CATEGORY_001","카테고리를 찾을 없음"),
     NOT_FOUND_THEME_EXCEPTION(HttpStatus.NOT_FOUND, "THEME_001", "테마를 찾을 수 없음"),
-    NOT_FOUND_PRODUCT_EXCEPTION(HttpStatus.NOT_FOUND, "PRODUCT_001", "상품을 찾을 수 없음");
+    NOT_FOUND_PRODUCT_EXCEPTION(HttpStatus.NOT_FOUND, "PRODUCT_001", "상품을 찾을 수 없음"),
+    NOT_FOUND_CONSULTING_STATUS_EXCEPTION(HttpStatus.NOT_FOUND, "CONSULTING_001", "상담 상태를 찾을 수 없음");
 
     private final String code;
     private final String message;

--- a/real-common/src/main/java/com/example/real_common/global/exception/GlobalExceptionHandler.java
+++ b/real-common/src/main/java/com/example/real_common/global/exception/GlobalExceptionHandler.java
@@ -119,6 +119,7 @@ public class GlobalExceptionHandler {
                 .code(errorCode.getCode())
                 .build();
 
+        CommonResponse response = CommonResponse.builder()
                 .success(false)
                 .error(error)
                 .build();

--- a/real-common/src/main/java/com/example/real_common/global/exception/GlobalExceptionHandler.java
+++ b/real-common/src/main/java/com/example/real_common/global/exception/GlobalExceptionHandler.java
@@ -108,4 +108,24 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(response, errorCode.getStatus());
     }
 
+    @ExceptionHandler(NotFoundConsultingStatusException.class)
+    protected ResponseEntity<?> handleNotFoundConsultingStatusException(NotFoundConsultingStatusException exception) {
+        log.error("handleNotFoundConsultingStatusException :: ");
+        ErrorCode errorCode = ErrorCode.NOT_FOUND_CONSULTING_STATUS_EXCEPTION;
+
+        ErrorResponse error = ErrorResponse.builder()
+                .status(errorCode.getStatus().value())
+                .message(errorCode.getMessage())
+                .code(errorCode.getCode())
+                .build();
+
+                .success(false)
+                .error(error)
+                .build();
+
+        return new ResponseEntity<>(response, errorCode.getStatus());
+    }
+
+
+
 }

--- a/real-common/src/main/java/com/example/real_common/global/exception/error/NotFoundConsultingStatusException.java
+++ b/real-common/src/main/java/com/example/real_common/global/exception/error/NotFoundConsultingStatusException.java
@@ -1,0 +1,16 @@
+package com.example.real_common.global.exception.error;
+
+public class NotFoundConsultingStatusException extends RuntimeException {
+    public NotFoundConsultingStatusException() {
+        super();
+    }
+    public NotFoundConsultingStatusException(String message) {
+        super(message);
+    }
+    public NotFoundConsultingStatusException(String message, Throwable cause) {
+        super(message, cause);
+    }
+    public NotFoundConsultingStatusException(Throwable cause) {
+        super(cause);
+    }
+}


### PR DESCRIPTION
### PR 타입
-[✅ ] 기능 추가
-[] 기능 수정
-[] 기능 삭제
-[] 버그 수정
-[] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
 feature/PICKLE-102-com-request-letters -> dev

### 변경 사항
- ConsultingConfirmDate (PB의 상담확정시간)
- 기능 변경에 따라 ConsultingConfirmDate에 확정된 상담 시간을 저장하는 것이 아니라, ConsultingHistory에 date 컬럼을 추가하여 저장할 수도 있을 것 같음
- AnswerType은 고객이 선택한 번호를 관리하기 위한 Enum, 프론트에서 0번부터 준다고 했음
- ConsultingStatusEnum 상담 상태 관리를 위한 Enum

