### PR TITLE
Feat: 요청서 작성 API 완성

### DIFF
--- a/pickle-common/src/main/java/com/example/pickle_common/consulting/controller/CustomerConsultingController.java
+++ b/pickle-common/src/main/java/com/example/pickle_common/consulting/controller/CustomerConsultingController.java
@@ -8,9 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/pickle-common/consulting/customer")
@@ -18,10 +16,9 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class CustomerConsultingController {
     private final CustomerConsultingService customerConsultingService;
-
     @PostMapping("/request-letters")
-    public ResponseEntity<CommonResDto<?>> createRequestLetter(CreateRequestLetterRequestDto requestDto) {
-        CreateRequestLetterResponseDto result = customerConsultingService.createRequestLetter(requestDto);
+    public ResponseEntity<CommonResDto<?>> createRequestLetter(@RequestHeader("Authorization") String authorizationHeader,@RequestBody CreateRequestLetterRequestDto requestDto) {
+        CreateRequestLetterResponseDto result = customerConsultingService.createRequestLetter(authorizationHeader, requestDto);
         return ResponseEntity.status(HttpStatus.CREATED).body(new CommonResDto<>(1, "요청서 생성 성공", result));
     }
 }

--- a/pickle-common/src/main/java/com/example/pickle_common/consulting/dto/CreateRequestLetterRequestDto.java
+++ b/pickle-common/src/main/java/com/example/pickle_common/consulting/dto/CreateRequestLetterRequestDto.java
@@ -13,7 +13,6 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 public class CreateRequestLetterRequestDto {
     private LocalDateTime date; // 상담일자
-    private LocalDateTime startTime; // 상담시작시간
     private String request;
 
     private int answer1;
@@ -35,7 +34,7 @@ public class CreateRequestLetterRequestDto {
     @NoArgsConstructor
     public static class CustomerInfo {
         private int customerAge;
-        private String customerGender;
+        private int customerGender;
         private String customerJob;
     }
 

--- a/pickle-common/src/main/java/com/example/pickle_common/consulting/entity/AnswerType.java
+++ b/pickle-common/src/main/java/com/example/pickle_common/consulting/entity/AnswerType.java
@@ -1,7 +1,7 @@
 package com.example.pickle_common.consulting.entity;
 
 public enum AnswerType {
-    NONE(0),
+    OPTION_ZERO(0),
     OPTION_ONE(1),
     OPTION_TWO(2),
     OPTION_THREE(3);

--- a/pickle-common/src/main/java/com/example/pickle_common/consulting/entity/ConsultingHistory.java
+++ b/pickle-common/src/main/java/com/example/pickle_common/consulting/entity/ConsultingHistory.java
@@ -8,6 +8,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
 import java.util.Date;
 
 @Entity
@@ -31,6 +32,7 @@ public class ConsultingHistory extends BaseTimeEntity {
 
     private String roomId;
     private String pbImage;
+    private LocalDateTime date;
 
     @Enumerated(EnumType.STRING)
     private ConsultingStatusEnum consultingStatusName;
@@ -39,9 +41,9 @@ public class ConsultingHistory extends BaseTimeEntity {
     // OneToOne 양방향 매핑에서는 fetch LAZY 적용이 안되는 상황이 많다.
     @OneToOne(mappedBy = "consultingHistory", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private RequestLetter requestLetter;
-
-    @OneToOne(mappedBy = "consultingHistory", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
-    private ConsultingConfirmDate consultingConfirmDate;
+//
+//    @OneToOne(mappedBy = "consultingHistory", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+//    private ConsultingConfirmDate consultingConfirmDate;
 
     // 전략과 양방향 매핑
 //    @OneToOne(mappedBy = "consultingHistory", cascade = CascadeType.ALL, fetch = FetchType.LAZY)

--- a/pickle-common/src/main/java/com/example/pickle_common/consulting/entity/GenderType.java
+++ b/pickle-common/src/main/java/com/example/pickle_common/consulting/entity/GenderType.java
@@ -1,0 +1,24 @@
+package com.example.pickle_common.consulting.entity;
+
+public enum GenderType {
+    MALE(0), FEMALE(1);
+
+    private final int value;
+
+    private GenderType(int value) {
+        this.value = value;
+    }
+
+    public int getValue() {
+        return value;
+    }
+
+    public static GenderType fromValue(int value) {
+        for (GenderType type : GenderType.values()) {
+            if (type.getValue() == value) {
+                return type;
+            }
+        }
+        throw new IllegalArgumentException("Invalid value for GenderType: " + value);
+    }
+}

--- a/pickle-common/src/main/java/com/example/pickle_common/consulting/entity/RequestLetter.java
+++ b/pickle-common/src/main/java/com/example/pickle_common/consulting/entity/RequestLetter.java
@@ -29,8 +29,11 @@ public class RequestLetter extends BaseTimeEntity {
 
     private int customerId;
     private int customerAge;
-    private String customerGender;
     private String customerJob;
+
+
+    @Enumerated(EnumType.STRING)
+    private GenderType customerGender;
 
     private String request;
     @Enumerated(EnumType.STRING)

--- a/pickle-common/src/main/java/com/example/pickle_common/consulting/service/CustomerConsultingService.java
+++ b/pickle-common/src/main/java/com/example/pickle_common/consulting/service/CustomerConsultingService.java
@@ -2,15 +2,15 @@ package com.example.pickle_common.consulting.service;
 
 import com.example.pickle_common.consulting.dto.CreateRequestLetterRequestDto;
 import com.example.pickle_common.consulting.dto.CreateRequestLetterResponseDto;
-import com.example.pickle_common.consulting.entity.AnswerType;
-import com.example.pickle_common.consulting.entity.ConsultingHistory;
-import com.example.pickle_common.consulting.entity.ConsultingStatusEnum;
-import com.example.pickle_common.consulting.entity.RequestLetter;
+import com.example.pickle_common.consulting.entity.*;
 import com.example.pickle_common.consulting.repository.ConsultingConfirmDateRepository;
 import com.example.pickle_common.consulting.repository.ConsultingHistoryRepository;
 import com.example.pickle_common.consulting.repository.ConsultingRejectInfoRepository;
 import com.example.pickle_common.consulting.repository.RequestLetterRepository;
+import com.example.pickle_common.mq.MessageQueueService;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import java.util.UUID;
@@ -18,12 +18,14 @@ import java.util.UUID;
 @Service
 @RequiredArgsConstructor
 public class CustomerConsultingService {
+    private static final Logger log = LoggerFactory.getLogger(CustomerConsultingService.class);
     private final RequestLetterRepository requestLetterRepository;
     private final ConsultingHistoryRepository consultingHistoryRepository;
     private final ConsultingConfirmDateRepository consultingConfirmDateRepository;
     private final ConsultingRejectInfoRepository consultingRejectInfoRepository;
+    private final MessageQueueService messageQueueService;
 
-    public CreateRequestLetterResponseDto createRequestLetter(CreateRequestLetterRequestDto requestDto) {
+    public CreateRequestLetterResponseDto createRequestLetter(String authorizationHeader,CreateRequestLetterRequestDto requestDto) {
         //상담기록이 먼저 생성 되어야 한다.
         /**
          * TODO 현재는 더미값임.
@@ -32,23 +34,28 @@ public class CustomerConsultingService {
          * customername추가
          */
         // UUID를 사용해 난수 생성
+        String pbNumber = requestDto.getPbInfo().getPbNumber();
+        int pbId = messageQueueService.getPbIdByPbNumberbySync(pbNumber);
+        int customerId = messageQueueService.getCustomerIdByCustomerToken(authorizationHeader);
+        String customerName = messageQueueService.getCustomerNameByCustomerToken(authorizationHeader);
         String randomString = UUID.randomUUID().toString();
         ConsultingHistory consultingHistory = ConsultingHistory.builder()
-                .customerId(0)
-                .pbId(0)
+                .customerId(customerId)
+                .customerName(customerName)
+                .pbId(pbId)
                 .consultingStatusName(ConsultingStatusEnum.REQUESTED)
                 .roomId(randomString)
                 .pbName(requestDto.getPbInfo().getName())
                 .pbBranchOffice(requestDto.getPbInfo().getBranchOffice())
-                .customerName("이름들어가야함")
+                .date(requestDto.getDate())
+                .customerName(customerName)
                 .build();
         ConsultingHistory savedConsultingHistory = consultingHistoryRepository.save(consultingHistory);
 
-        // 이제 요청서 생성
-        // 여기도 id값 제대로 넣어줘야함
+
         RequestLetter requestLetter = RequestLetter.builder()
                 .consultingHistory(savedConsultingHistory)
-                .customerId(0)
+                .customerId(customerId)
                 .request(requestDto.getRequest())
                 .answer1(AnswerType.fromValue(requestDto.getAnswer1()))
                 .answer2(AnswerType.fromValue(requestDto.getAnswer2()))
@@ -57,6 +64,10 @@ public class CustomerConsultingService {
                 .availableInvestAmount(requestDto.getAvailableInvestAmount())
                 .desiredInvestAmount(requestDto.getDesiredInvestAmount())
                 .monthlyIncome(requestDto.getMonthlyIncome())
+                .customerGender(GenderType.fromValue(requestDto.getCustomerInfo().getCustomerGender()))
+                .customerAge(requestDto.getCustomerInfo().getCustomerAge())
+                .customerJob(requestDto.getCustomerInfo().getCustomerJob())
+                .referenceFileUrl(requestDto.getReferenceFileUrl())
                 .build();
         RequestLetter savedRequestLetter = requestLetterRepository.save(requestLetter);
 

--- a/pickle-common/src/main/java/com/example/pickle_common/mq/MessageQueueService.java
+++ b/pickle-common/src/main/java/com/example/pickle_common/mq/MessageQueueService.java
@@ -32,12 +32,13 @@ public class MessageQueueService {
     }
 
     /***
-     * token을 보내 pb의 pk를 반환받는 메소드
-     * @param token
+     * authorizationHeader를 보내 pb의 pk를 반환받는 메소드
+     * @param authorizationHeader
      * @return pbId
      */
-    public int getPbIdByPbToken(String token){
+    public int getPbIdByPbToken(String authorizationHeader){
         try {
+            String token = authorizationHeader.substring(7);
             Integer pbId = (Integer) rabbitTemplate.convertSendAndReceive(
                     RabbitMQConfig.PB_EXCHANGE, RabbitMQConfig.PB_TOKEN_TO_ID_ROUTING_KEY, token, message -> {
                         message.getMessageProperties().setExpiration("4000");
@@ -51,12 +52,13 @@ public class MessageQueueService {
     }
 
     /***
-     * token을 보내 customer의 pk를 반환받는 메소드
-     * @param token
+     * authorizationHeader를 보내 customer의 pk를 반환받는 메소드
+     * @param authorizationHeader
      * @return customerId
      */
-    public int getCustomerIdByCustomerToken(String token){
+    public int getCustomerIdByCustomerToken(String authorizationHeader){
         try {
+            String token = authorizationHeader.substring(7);
             Integer customerId = (Integer) rabbitTemplate.convertSendAndReceive(
                     RabbitMQConfig.CUSTOMER_EXCHANGE, RabbitMQConfig.CUSTOMER_TOKEN_TO_ID_ROUTING_KEY, token, message -> {
                         message.getMessageProperties().setExpiration("4000");

--- a/pickle-common/src/main/java/com/example/pickle_common/mq/MessageQueueService.java
+++ b/pickle-common/src/main/java/com/example/pickle_common/mq/MessageQueueService.java
@@ -70,5 +70,24 @@ public class MessageQueueService {
             return RabbitMQConfig.INVALID_TOKEN;
         }
     }
-
+    /***
+     * authorizationHeader를 보내 customer의 info를 반환받는 메소드
+     * @param authorizationHeader
+     * @return customerId
+     */
+    public String getCustomerNameByCustomerToken(String authorizationHeader){
+        try {
+            String token = authorizationHeader.substring(7);
+            String name = (String) rabbitTemplate.convertSendAndReceive(
+                    RabbitMQConfig.CUSTOMER_EXCHANGE, RabbitMQConfig.CUSTOMER_TOKEN_TO_NAME_ROUTING_KEY, token, message -> {
+                        message.getMessageProperties().setExpiration("4000");
+                        return message;
+                    }
+            );
+            System.out.println(name);
+            return name;
+        } catch (Exception e) {
+            return new RabbitMQConfig().UNKNOWN_CUSTOMER;
+        }
+    }
 }

--- a/pickle-customer/src/main/java/com/example/pickle_customer/service/CustomerMessageListener.java
+++ b/pickle-customer/src/main/java/com/example/pickle_customer/service/CustomerMessageListener.java
@@ -1,9 +1,12 @@
 package com.example.pickle_customer.service;
 
 import com.example.pickle_customer.auth.JwtService;
+import com.example.pickle_customer.entity.Customer;
 import com.example.pickle_customer.repository.CustomerRepository;
 import com.example.real_common.config.RabbitMQConfig;
 import lombok.AllArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.stereotype.Service;
 
@@ -11,6 +14,7 @@ import org.springframework.stereotype.Service;
 @AllArgsConstructor
 public class CustomerMessageListener {
 
+    private static final Logger log = LoggerFactory.getLogger(CustomerMessageListener.class);
     private final CustomerRepository customerRepository;
     private final JwtService jwtService;
 
@@ -20,7 +24,7 @@ public class CustomerMessageListener {
      * @return customer의 PK, 없다면 -1 반환
      */
     @RabbitListener(queues = RabbitMQConfig.CUSTOMER_TOKEN_TO_ID_CONVERSION_QUEUE)
-    public Integer handlePbTokenRequest(String customerToken) {
+    public Integer handleCustomerTokenRequest(String customerToken) {
         try{
             jwtService.validateToken(customerToken);
             return Integer.parseInt(jwtService.extractUsername(customerToken));
@@ -28,5 +32,26 @@ public class CustomerMessageListener {
             return RabbitMQConfig.INVALID_TOKEN;
         }
     }
+
+    /**
+     * 토큰으로 고객의 정보인 이름와 ID(PK)를 반환하는 메소드
+     * @param customerToken
+     * @return
+     */
+    @RabbitListener(queues = RabbitMQConfig.CUSTOMER_TOKEN_TO_NAME_CONVERSION_QUEUE)
+    public String handleCustomerInfoRequest(String customerToken) {
+        try {
+            jwtService.validateToken(customerToken);
+            int customerId = Integer.parseInt(jwtService.extractUsername(customerToken));
+            System.out.println(customerId+"CU");
+            System.out.println(customerRepository.findByCustomerId(customerId).map(Customer::getName).orElseThrow(RuntimeException::new));
+            return customerRepository.findByCustomerId(customerId).map(Customer::getName).orElse(RabbitMQConfig.UNKNOWN_CUSTOMER);
+        } catch (NumberFormatException e) {
+            return RabbitMQConfig.UNKNOWN_CUSTOMER;
+        } catch (RuntimeException e) {
+            return RabbitMQConfig.UNKNOWN_CUSTOMER;
+        }
+    }
+
 
 }

--- a/real-common/src/main/java/com/example/real_common/config/RabbitMQConfig.java
+++ b/real-common/src/main/java/com/example/real_common/config/RabbitMQConfig.java
@@ -15,16 +15,20 @@ public class RabbitMQConfig {
     public static final String PB_NUMBER_TO_ID_ROUTING_KEY = "pbRoutingKey.pbNumber";
     public static final String PB_TOKEN_TO_ID_ROUTING_KEY = "pbTokenRoutingKey.pbToken";
     public static final String CUSTOMER_TOKEN_TO_ID_ROUTING_KEY = "customerTokenRoutingKey.customerToken";
+    public static final String CUSTOMER_TOKEN_TO_NAME_ROUTING_KEY = "customerTokenTokenNameRoutingKey.customerToken";
 
     // Queue names
     public static final String PB_NUMBER_TO_ID_CONVERSION_QUEUE = "pbIdbyNumberQueue";
     public static final String PB_TOKEN_TO_ID_CONVERSION_QUEUE = "pbIdbyTokenQueue";
     public static final String CUSTOMER_TOKEN_TO_ID_CONVERSION_QUEUE = "customerIdbyTokenQueue";
     public static final String DEAD_LETTER_QUEUE_NAME = "deadLetterQueue";
+    public static final String CUSTOMER_TOKEN_TO_NAME_CONVERSION_QUEUE = "customerTokenNameQueue";
+
 
     //constants
     public static final int INVALID_PB_NUMBER = -1;
     public static final int INVALID_TOKEN = -1;
+    public static final String UNKNOWN_CUSTOMER ="Unknown Customer";
 
     // Exchanges
     @Bean
@@ -69,6 +73,12 @@ public class RabbitMQConfig {
                 .build();
     }
 
+    @Bean
+    public Queue customerNameByTokenQueue() {
+        return QueueBuilder.durable(CUSTOMER_TOKEN_TO_NAME_CONVERSION_QUEUE).withArgument("x-dead-letter-exchange", "deadLetterExchange")
+                .build();
+    }
+
     //Binding
     @Bean
     public Binding pbNumberToIdBinding() {
@@ -91,6 +101,12 @@ public class RabbitMQConfig {
                 .with(CUSTOMER_TOKEN_TO_ID_ROUTING_KEY);
     }
 
+    @Bean
+    public Binding customerTokenNamefoBinding() {
+        return BindingBuilder.bind(customerNameByTokenQueue())
+                .to(customerExchange())
+                .with(CUSTOMER_TOKEN_TO_NAME_ROUTING_KEY);
+    }
     /***
      * 메시지가 정상적으로 처리되지 못했을 때, Dead Letter Exchange가 보내는 메시지를 저장하는 큐
      * @return


### PR DESCRIPTION
### PR 타입
-[✅] 기능 추가
-[✅] 기능 수정
-[] 기능 삭제
-[] 버그 수정
-[] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feature/PICKLE-102-com-request-letters -> develop

### 변경 사항
- mq이용하여 pb의 id, customer의 id, name 가져와 저장하기
- date와 startTime을 한 번에 date에 저장
- 성별도 genderType Enum으로 저장하기 위해 생성
- 수락 시, 룸ID생성으로 추후 변경

### 테스트 결과
![image](https://github.com/user-attachments/assets/6800ee2b-8acf-4a1a-9b4e-0464ed60d0a8)
