### PR TITLE
Feature/pickle 129 read presets by group

### DIFF
--- a/pickle-pb/src/main/java/com/example/pickle_pb/preset/controller/PresetController.java
+++ b/pickle-pb/src/main/java/com/example/pickle_pb/preset/controller/PresetController.java
@@ -30,6 +30,12 @@ public class PresetController {
         return ResponseEntity.status(HttpStatus.OK).body(new CommonResDto<>(1, "프리셋 상세 조회 완료", result));
     }
 
+    @GetMapping("/presetGroupId/{presetGroupId}")
+    public ResponseEntity<CommonResDto<?>> readPresetListByGroupId(@PathVariable @Valid Integer presetGroupId) {
+        ReadPresetListResponseDto result = presetService.readPresetListByGroupId(presetGroupId);
+        return ResponseEntity.status(HttpStatus.OK).body(new CommonResDto<>(1, "프리셋 조회 완료", result));
+    }
+
     @PostMapping
     public ResponseEntity<CommonResDto<?>> createPreset(@RequestBody CreatePresetRequestDto requestDto) {
         CreatePresetResponseDto result = presetService.createPreset(requestDto);

--- a/pickle-pb/src/main/java/com/example/pickle_pb/preset/entity/PresetProductComposition.java
+++ b/pickle-pb/src/main/java/com/example/pickle_pb/preset/entity/PresetProductComposition.java
@@ -12,7 +12,7 @@ import lombok.*;
 public class PresetProductComposition extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "category_product_id")
+    @Column(name = "product_composition_id")
     private int id;
 
     @Column(length = 10, nullable = false)

--- a/pickle-pb/src/main/java/com/example/pickle_pb/preset/repository/PresetRepository.java
+++ b/pickle-pb/src/main/java/com/example/pickle_pb/preset/repository/PresetRepository.java
@@ -9,4 +9,6 @@ import java.util.Optional;
 
 public interface PresetRepository extends JpaRepository<Preset, Integer> {
     List<Preset> findByPresetGroup(PresetGroup presetGroup);
+
+    List<Preset> findAllByPresetGroup(PresetGroup group);
 }

--- a/pickle-pb/src/main/java/com/example/pickle_pb/presetGroup/repository/PresetGroupRepository.java
+++ b/pickle-pb/src/main/java/com/example/pickle_pb/presetGroup/repository/PresetGroupRepository.java
@@ -11,4 +11,5 @@ public interface PresetGroupRepository extends JpaRepository<PresetGroup, Intege
 
     List<PresetGroup> findAllByPbId(Integer pbId);
 
+    Optional<PresetGroup> findByIdAndPbId(Integer presetGroupId, int pbId);
 }

--- a/real-common/src/main/java/com/example/real_common/global/exception/ErrorCode.java
+++ b/real-common/src/main/java/com/example/real_common/global/exception/ErrorCode.java
@@ -16,7 +16,7 @@ public enum ErrorCode {
     UN_AUTHORIZED_EXCEPTION(HttpStatus.UNAUTHORIZED, "ACCOUNT_002", "사용자의 권한이 아님"),
     NOT_FOUND_STRATEGY_EXCEPTION(HttpStatus.NOT_FOUND, "STRATEGY_001", "전략을 찾을 수 없음"),
     NOT_FOUND_MY_STRATEGY_EXCEPTION(HttpStatus.NOT_FOUND, "STRATEGY_001", "나의 전략을 찾을 수 없음"),
-
+    NOT_FOUND_PRESET_EXCEPTION(HttpStatus.NOT_FOUND, "PRESET_001", "프리셋을 찾을 수 없습니다."),
     CONFLICT_MY_STRATEGY_EXCEPTION(HttpStatus.CONFLICT, "MY_STRATEGY_002", "이미 나의 전략이 존재함"),
     NOT_FOUND_IMAGE_EXCEPTION(HttpStatus.NOT_FOUND, "IMAGE_001", "사진이 없습니다.");
     private final String code;

--- a/real-common/src/main/java/com/example/real_common/global/exception/GlobalExceptionHandler.java
+++ b/real-common/src/main/java/com/example/real_common/global/exception/GlobalExceptionHandler.java
@@ -223,7 +223,7 @@ public class GlobalExceptionHandler {
     protected ResponseEntity<?> handleNotFoundImageException(NotFoundImageException exception) {
         log.error("handleNotFoundImageException :: ");
         ErrorCode errorCode = ErrorCode.NOT_FOUND_IMAGE_EXCEPTION;
-    
+
         ErrorResponse error = ErrorResponse.builder()
                 .status(errorCode.getStatus().value())
                 .message(errorCode.getMessage())
@@ -242,6 +242,25 @@ public class GlobalExceptionHandler {
     protected ResponseEntity<?> handleNotFoundMyStrategyException(NotFoundMyStrategyException exception) {
         log.error("handleNotFoundMyStrategyException :: ");
         ErrorCode errorCode = ErrorCode.NOT_FOUND_MY_STRATEGY_EXCEPTION;
+
+        ErrorResponse error = ErrorResponse.builder()
+                .status(errorCode.getStatus().value())
+                .message(errorCode.getMessage())
+                .code(errorCode.getCode())
+                .build();
+
+        CommonResponse response = CommonResponse.builder()
+                .success(false)
+                .error(error)
+                .build();
+
+        return new ResponseEntity<>(response, errorCode.getStatus());
+    }
+
+    @ExceptionHandler(NotFoundPresetException.class)
+    protected ResponseEntity<?> handleNotFoundPresetException(NotFoundPresetException exception) {
+        log.error("handleNotFoundPresetException :: ");
+        ErrorCode errorCode = ErrorCode.NOT_FOUND_PRESET_EXCEPTION;
 
         ErrorResponse error = ErrorResponse.builder()
                 .status(errorCode.getStatus().value())

--- a/real-common/src/main/java/com/example/real_common/global/exception/error/NotFoundPresetException.java
+++ b/real-common/src/main/java/com/example/real_common/global/exception/error/NotFoundPresetException.java
@@ -1,0 +1,19 @@
+package com.example.real_common.global.exception.error;
+
+public class NotFoundPresetException extends RuntimeException {
+    public NotFoundPresetException() {
+        super();
+    }
+
+    public NotFoundPresetException(String message) {
+        super(message);
+    }
+
+    public NotFoundPresetException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public NotFoundPresetException(Throwable cause) {
+        super(cause);
+    }
+}


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가
- [x] 기능 수정

### 반영 브랜치
Feature/pickle 129 read presets by group -> dev

### 변경 사항
- 그룹id로 프리셋 리스트 조회하는 로직 추가
- 엔티티에 테이블명 잘못되어있는거 수정
- 기존 업데이트 로직 수정
   - 업데이트시, 기존 항목 수정이나 생성은 되었는데, 삭제의 경우 고려를 안했음..

### 테스트 결과
![image](https://github.com/user-attachments/assets/311654d5-af6e-42e7-9759-fe047a00b138)

![image](https://github.com/user-attachments/assets/0ff0b097-1e61-4aaf-90ba-fb1f8240bfdc)
