### PR TITLE
feat: 상담 수락 시, consultingRoomCreationQueue에 저장할 수 있도록 기능 추가

### DIFF
--- a/pickle-common/build.gradle
+++ b/pickle-common/build.gradle
@@ -33,6 +33,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+	implementation 'com.fasterxml.jackson.core:jackson-databind'
+	implementation 'javax.transaction:javax.transaction-api:1.3'
 }
 
 dependencyManagement {

--- a/pickle-common/src/main/java/com/example/pickle_common/consulting/dto/CreateRequestLetterRequest.java
+++ b/pickle-common/src/main/java/com/example/pickle_common/consulting/dto/CreateRequestLetterRequest.java
@@ -19,9 +19,9 @@ public class CreateRequestLetterRequest {
     private int answer2;
     private int answer3;
     private int answer4;
-    private int availableInvestAmount;
-    private int desiredInvestAmount;
-    private int monthlyIncome;
+    private long availableInvestAmount;
+    private long desiredInvestAmount;
+    private long monthlyIncome;
 
     private CustomerInfo customerInfo;
     private PbInfo pbInfo;

--- a/pickle-common/src/main/java/com/example/pickle_common/consulting/dto/CreateRequestLetterRequest.java
+++ b/pickle-common/src/main/java/com/example/pickle_common/consulting/dto/CreateRequestLetterRequest.java
@@ -32,7 +32,7 @@ public class CreateRequestLetterRequest {
     @AllArgsConstructor
     @Builder
     @NoArgsConstructor
-    public static class CustomerInfo {
+    public static class  CustomerInfo {
         private int customerAge;
         private int customerGender;
         private String customerJob;
@@ -46,7 +46,7 @@ public class CreateRequestLetterRequest {
     public static class PbInfo {
         private String pbNumber;
         private String name;
-        private String img;
+        private String image;
         private String branchOffice;
     }
 }

--- a/pickle-common/src/main/java/com/example/pickle_common/consulting/entity/ConsultingHistory.java
+++ b/pickle-common/src/main/java/com/example/pickle_common/consulting/entity/ConsultingHistory.java
@@ -26,14 +26,13 @@ public class ConsultingHistory extends BaseTimeEntity {
     private String pbName;
     private String pbBranchOffice;
     // TODO: 추가에 따른 로직 추가
-    private String pbImg;
+    private String pbImage;
 
     private int customerId;
     private String customerName;
 
 
     private String roomId;
-    private String pbImage;
     private LocalDateTime date;
 
     @Enumerated(EnumType.STRING)

--- a/pickle-common/src/main/java/com/example/pickle_common/consulting/service/CustomerConsultingService.java
+++ b/pickle-common/src/main/java/com/example/pickle_common/consulting/service/CustomerConsultingService.java
@@ -30,7 +30,6 @@ public class CustomerConsultingService {
     private final ConsultingHistoryRepository consultingHistoryRepository;
     private final ConsultingRejectInfoRepository consultingRejectInfoRepository;
     private final MessageQueueService messageQueueService;
-
     /**
      * 요청서 생성 메소드
      * @param authorizationHeader
@@ -62,7 +61,7 @@ public class CustomerConsultingService {
                 .roomId(null)
                 .pbName(requestDto.getPbInfo().getName())
                 .pbBranchOffice(requestDto.getPbInfo().getBranchOffice())
-                .pbImage(requestDto.getPbInfo().getImg())
+                .pbImage(requestDto.getPbInfo().getImage())
                 .date(requestDto.getDate())
                 .customerName(customerName)
                 .build();
@@ -85,6 +84,7 @@ public class CustomerConsultingService {
                 .customerJob(requestDto.getCustomerInfo().getCustomerJob())
                 .referenceFileUrl(requestDto.getReferenceFileUrl())
                 .build();
+
         RequestLetter savedRequestLetter = requestLetterRepository.save(requestLetter);
 
         return CreateRequestLetterResponse.builder()
@@ -163,10 +163,6 @@ public class CustomerConsultingService {
             for (ConsultingHistory consultingHistory : consultingHistories) {
                 RequestLetter requestLetter = requestLetterRepository.findByConsultingHistoryId(consultingHistory.getId());
                 ConsultingRejectInfo consultingRejectInfo = null;
-
-                if (ConsultingStatusEnum.REJECTED.name().equals(consultingHistory.getConsultingStatusName())) {
-                    consultingRejectInfo = consultingRejectInfoRepository.findByConsultingHistoryId(consultingHistory.getId());
-                }
 
                 ConsultingResponse consultingResponse = ConsultingResponse.builder()
                         .requestLetterId(requestLetter.getId())

--- a/pickle-common/src/main/java/com/example/pickle_common/mq/MessageQueueService.java
+++ b/pickle-common/src/main/java/com/example/pickle_common/mq/MessageQueueService.java
@@ -89,4 +89,21 @@ public class MessageQueueService {
             return new RabbitMQConfig().UNKNOWN_CUSTOMER;
         }
     }
+
+    /**
+     * json형식의 상담룸 정보를 보내는 메소드
+     * @param jsonMessage 상담룸 정보를 가진 Message
+     */
+    public boolean sendMessage(String jsonMessage) {
+        try {
+            rabbitTemplate.convertAndSend(
+                    RabbitMQConfig.CONSULTING_EXCHANGE,
+                    RabbitMQConfig.CONSULTING_ROOM_CREATION_ROUNTING_KEY,
+                    jsonMessage);
+            System.out.println(jsonMessage);
+            return true;
+        }catch (Exception e){
+            return false;
+        }
+    }
 }

--- a/pickle-common/src/main/resources/application.yml
+++ b/pickle-common/src/main/resources/application.yml
@@ -12,8 +12,13 @@ spring:
     username: ${COMMON_DATASOURCE_USERNAME}
     password: ${COMMON_DATASOURCE_PASSWORD}
   jpa:
-    hibernate:
-      ddl-auto: update
+    properties:
+      hibernate:
+        ddl-auto: update
+        transaction:
+          jta:
+            platform: org.hibernate.service.jta.platform.internal.JBossAppServerJtaPlatform
+
 
   application:
     name: pickle-common  # 서비스 이름

--- a/real-common/src/main/java/com/example/real_common/config/RabbitMQConfig.java
+++ b/real-common/src/main/java/com/example/real_common/config/RabbitMQConfig.java
@@ -10,20 +10,20 @@ public class RabbitMQConfig {
     public static final String PB_EXCHANGE = "pb.direct.exchange";
     public static final String COMMON_EXCHANGE = "common.direct.exchange";
     public static final String CUSTOMER_EXCHANGE = "customer.direct.exchange";
-
+    public static final String CONSULTING_EXCHANGE = "realtime.consulting.exchange";
     // Routing keys
     public static final String PB_NUMBER_TO_ID_ROUTING_KEY = "pbRoutingKey.pbNumber";
     public static final String PB_TOKEN_TO_ID_ROUTING_KEY = "pbTokenRoutingKey.pbToken";
     public static final String CUSTOMER_TOKEN_TO_ID_ROUTING_KEY = "customerTokenRoutingKey.customerToken";
     public static final String CUSTOMER_TOKEN_TO_NAME_ROUTING_KEY = "customerTokenTokenNameRoutingKey.customerToken";
+    public static final String CONSULTING_ROOM_CREATION_ROUNTING_KEY = "transferRoomInfoRoutingKey";
 
     // Queue names
     public static final String PB_NUMBER_TO_ID_CONVERSION_QUEUE = "pbIdbyNumberQueue";
     public static final String PB_TOKEN_TO_ID_CONVERSION_QUEUE = "pbIdbyTokenQueue";
     public static final String CUSTOMER_TOKEN_TO_ID_CONVERSION_QUEUE = "customerIdbyTokenQueue";
-    public static final String DEAD_LETTER_QUEUE_NAME = "deadLetterQueue";
     public static final String CUSTOMER_TOKEN_TO_NAME_CONVERSION_QUEUE = "customerTokenNameQueue";
-
+    public static final String CONSULTING_ROOM_CREATION_QUEUE = "consultingRoomCreationQueue";
 
     //constants
     public static final int INVALID_PB_NUMBER = -1;
@@ -49,39 +49,37 @@ public class RabbitMQConfig {
     }
 
     @Bean
-    public DirectExchange deadLetterExchange() {
-        return new DirectExchange("deadLetterExchange");
+    public DirectExchange consultingExchange() {
+        return new DirectExchange(CONSULTING_EXCHANGE);
     }
 
     // Queues
     @Bean
     public Queue pbIdByNumberQueue() {
-        return QueueBuilder.durable(PB_NUMBER_TO_ID_CONVERSION_QUEUE)
-                .withArgument("x-dead-letter-exchange", "deadLetterExchange")
-                .build();
+        return QueueBuilder.durable(PB_NUMBER_TO_ID_CONVERSION_QUEUE).build();
     }
 
     @Bean
     public Queue pbIdByTokenQueue() {
-        return QueueBuilder.durable(PB_TOKEN_TO_ID_CONVERSION_QUEUE)
-                .withArgument("x-dead-letter-exchange", "deadLetterExchange")
-                .build();
+        return QueueBuilder.durable(PB_TOKEN_TO_ID_CONVERSION_QUEUE).build();
     }
 
     @Bean
     public Queue customerIdbyNumberQueue() {
-        return QueueBuilder.durable(CUSTOMER_TOKEN_TO_ID_CONVERSION_QUEUE)
-                .withArgument("x-dead-letter-exchange", "deadLetterExchange")
-                .build();
+        return QueueBuilder.durable(CUSTOMER_TOKEN_TO_ID_CONVERSION_QUEUE).build();
     }
 
     @Bean
     public Queue customerNameByTokenQueue() {
-        return QueueBuilder.durable(CUSTOMER_TOKEN_TO_NAME_CONVERSION_QUEUE).withArgument("x-dead-letter-exchange", "deadLetterExchange")
-                .build();
+        return QueueBuilder.durable(CUSTOMER_TOKEN_TO_NAME_CONVERSION_QUEUE).build();
     }
 
-    //Binding
+    @Bean
+    public Queue consultingRoomInfoQueue() {
+        return QueueBuilder.durable(CONSULTING_ROOM_CREATION_QUEUE).build();
+    }
+
+    // Bindings
     @Bean
     public Binding pbNumberToIdBinding() {
         return BindingBuilder.bind(pbIdByNumberQueue())
@@ -109,21 +107,12 @@ public class RabbitMQConfig {
                 .to(customerExchange())
                 .with(CUSTOMER_TOKEN_TO_NAME_ROUTING_KEY);
     }
-    /***
-     * 메시지가 정상적으로 처리되지 못했을 때, Dead Letter Exchange가 보내는 메시지를 저장하는 큐
-     * @return
-     */
+
     @Bean
-    public Queue deadLetterQueue() {
-        return QueueBuilder.durable(DEAD_LETTER_QUEUE_NAME).build();
+    public Binding consultingRoomInfoBinding() {
+        return BindingBuilder.bind(consultingRoomInfoQueue())
+                .to(consultingExchange())
+                .with(CONSULTING_ROOM_CREATION_ROUNTING_KEY);
     }
 
-    /***
-     * Dead Letter Exchange (DLX)와 DLQ 바인딩
-     * @return
-     */
-    @Bean
-    public Binding deadLetterBinding() {
-        return BindingBuilder.bind(deadLetterQueue()).to(deadLetterExchange()).with("#");
-    }
 }

--- a/real-common/src/main/java/com/example/real_common/global/exception/ErrorCode.java
+++ b/real-common/src/main/java/com/example/real_common/global/exception/ErrorCode.java
@@ -25,8 +25,8 @@ public enum ErrorCode {
     NOT_FOUND_PRESET_EXCEPTION(HttpStatus.NOT_FOUND, "PRESET_001", "프리셋을 찾을 수 없습니다."),
     UNAUTHORIZED_STRATEGY_EXCEPTION(HttpStatus.UNAUTHORIZED, "STRATEGY_002", "접근할 권한이 없는 전략임"),
     ILLEGAL_ARGUMENT_AMOUNT_EXCEPTION(HttpStatus.BAD_REQUEST, "AMOUNT_001", "잔액 이상의 값을 매매할 수 없음"),
-    UNABLE_TO_CREATE_REJECTED_INFO_EXCEPTION(HttpStatus.BAD_REQUEST, "CONSULTING_005", "거절 내역을 저장할 수 없어, 거절을 할 수 없음");
-
+    UNABLE_TO_CREATE_REJECTED_INFO_EXCEPTION(HttpStatus.BAD_REQUEST, "CONSULTING_005", "거절 내역을 저장할 수 없어, 거절을 할 수 없음"),
+    UNABLE_TO_SEND_ROOM_INFO_TO_MQ_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "CONSULTING_006", "상담방을 생성할 수 없음" );
     private final String code;
     private final String message;
     private final HttpStatus status;

--- a/real-common/src/main/java/com/example/real_common/global/exception/GlobalExceptionHandler.java
+++ b/real-common/src/main/java/com/example/real_common/global/exception/GlobalExceptionHandler.java
@@ -295,7 +295,7 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(UnableToCreateRequestLetterDuoToMqFailure.class)
-    protected ResponseEntity<?> handleUnableToFetchMqDataException(UnableToCreateRequestLetterDuoToMqFailure exception){
+    protected ResponseEntity<?> UnableToCreateRequestLetterDuoToMqFailure(UnableToCreateRequestLetterDuoToMqFailure exception){
         log.error("handleUnableToFetchMqDataException :: ");
         ErrorCode errorCode = ErrorCode.UNABLE_TO_CREATE_REQUEST_LETTER_DUE_TO_MQ_FAILURE;
 
@@ -336,6 +336,25 @@ public class GlobalExceptionHandler {
     protected ResponseEntity<?> handleUnableToCreateRejectedInfoException(UnableToCreateRejectedInfoException exception){
         log.error("UnableToCreateRejectedInfoException :: ");
         ErrorCode errorCode = ErrorCode.UNABLE_TO_CREATE_REJECTED_INFO_EXCEPTION;
+
+        ErrorResponse error = ErrorResponse.builder()
+                .status(errorCode.getStatus().value())
+                .message(errorCode.getMessage())
+                .code(errorCode.getCode())
+                .build();
+
+        CommonResponse response = CommonResponse.builder()
+                .success(false)
+                .error(error)
+                .build();
+
+        return new ResponseEntity<>(response, errorCode.getStatus());
+    }
+
+    @ExceptionHandler(UnableToSendRoomInfoToMqException.class)
+    protected ResponseEntity<?> handleUnableToSendRoomInfoToMqException(UnableToSendRoomInfoToMqException exception){
+        log.error("UnableToSendRoomInfoToMqException :: ");
+        ErrorCode errorCode = ErrorCode.UNABLE_TO_SEND_ROOM_INFO_TO_MQ_EXCEPTION;
 
         ErrorResponse error = ErrorResponse.builder()
                 .status(errorCode.getStatus().value())

--- a/real-common/src/main/java/com/example/real_common/global/exception/error/UnableToSendRoomInfoToMqException.java
+++ b/real-common/src/main/java/com/example/real_common/global/exception/error/UnableToSendRoomInfoToMqException.java
@@ -1,0 +1,16 @@
+package com.example.real_common.global.exception.error;
+
+public class UnableToSendRoomInfoToMqException extends RuntimeException{
+    public UnableToSendRoomInfoToMqException() {
+        super();
+    }
+    public UnableToSendRoomInfoToMqException(String message) {
+        super(message);
+    }
+    public UnableToSendRoomInfoToMqException(String message, Throwable cause) {
+        super(message, cause);
+    }
+    public UnableToSendRoomInfoToMqException(Throwable cause) {
+        super(cause);
+    }
+}


### PR DESCRIPTION
### PR 타입
-[ ✅ ] 기능 추가
-[] 기능 수정
-[] 기능 삭제
-[] 버그 수정
-[] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feature/request-letters-process-PICKLE-130

### 변경 사항
상담 수락시, 룸정보가 mq에 가도록 하였습니다.
노드 서버에서 listen하는 mq 이름 변경이 필요합니다.
